### PR TITLE
Patch Compatibility Python 3.10

### DIFF
--- a/bison/__version__.py
+++ b/bison/__version__.py
@@ -3,7 +3,7 @@
 __title__ = 'bison'
 __description__ = 'Python application configuration'
 __url__ = 'https://github.com/edaniszewski/bison'
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 __author__ = 'Erick Daniszewski'
 __author_email__ = 'edaniszewski@gmail.com'
 __license__ = 'MIT'

--- a/bison/utils.py
+++ b/bison/utils.py
@@ -6,7 +6,7 @@ bison.utils
 Utilities for `bison`.
 """
 
-import collections
+import collections.abc
 
 
 def build_dot_value(key, value):
@@ -216,12 +216,12 @@ def _merge(d, u):
     """
     for k, v in u.items():
         # if we have a mapping, recursively merge the values
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             d[k] = _merge(d.get(k, {}), v)
 
         # if d (the dict to merge into) is a dict, just add the
         # value to the dict.
-        elif isinstance(d, collections.MutableMapping):
+        elif isinstance(d, collections.abc.MutableMapping):
             d[k] = v
 
         # otherwise if d (the dict to merge into) is not a dict (e.g. when


### PR DESCRIPTION
Changed collections import to collections.abc for compatibility with python 3.10.
The alias was deprecated and has been removed: https://docs.python.org/3/whatsnew/3.10.html

> Remove deprecated aliases to [Collections Abstract Base Classes](https://docs.python.org/3/library/collections.abc.html#collections-abstract-base-classes) from the [collections](https://docs.python.org/3/library/collections.html#module-collections) module.